### PR TITLE
Explaining differences between API signing key and SSH key

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ The following resources are deployed within the free-tier offer:
    - `fingerprint`
    - `region`
 
+   Please be careful with the value `private_key_path`, as this is not your SSH private key but the [API signing key](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm#two).
+
 1. Depending on your chosen `region`, retrieve the image ID from
    [this page](https://docs.oracle.com/en-us/iaas/images/) for your instances.
 

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -1,7 +1,7 @@
 # Refer to the README.md file to fill these in
 tenancy_ocid     = ""
 user_ocid        = ""
-private_key_path = "~/.oci/secret.pem"
+private_key_path = ""
 fingerprint      = ""
 region           = "ap-sydney-1"
 


### PR DESCRIPTION
This PR clarifies the confusion between the API signing key and SSH key and resolves #1.