### PR TITLE
Make provider compatible with ARM64.

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     oci = {
       source  = "hashicorp/oci"
-      version = "~> 4.61.0"
+      version = ">= 4.0.0"
     }
   }
 }


### PR DESCRIPTION
The current version is not compatible with ARM64 architecture. This MR changes the version tag to allow ARM64 to use this project.